### PR TITLE
Make tag links respect site BaseURL

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,7 +17,7 @@
 		  {{ if .Params.tags }}
 			<span class="post-tags">
 		  	{{ range .Params.tags }}
-			          #<a href="/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+			          #<a href="{{ $.Site.BaseURL }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
 		  	{{ end }}
 		    </span>
 		  {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
 		  {{ if .Params.tags }}
 			<span class="post-tags">
 		  	{{ range .Params.tags }}
-			          #<a href="/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+			          #<a href="{{ $.Site.BaseURL }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
 		  	{{ end }}
 		    </span>
 		  {{ end }}


### PR DESCRIPTION
Ran into this bug while using Shim's preview feature. This makes the tag links on pages respect a site's baseurl, so if hosting a blog under `example.com/blog/`, tags will now link to `example.com/blog/tag/tagname/` instead of the old (an broken) `example.com/tag/tagname/`.

Please accept this PR.

kthxbai